### PR TITLE
PHP 7.4.16 (initial release)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM silintl/php7-apache:7.4.16
+LABEL maintainer="matt_henderson@sil.org"
+
+RUN mkdir /app
+COPY check-version.php /app/
+
+WORKDIR /app
+CMD ["php", "/app/check-version.php"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Docker PHP7 Apache Updater
+
+This repo checks whether the
+[silintl/php7-apache](https://hub.docker.com/r/silintl/php7-apache) Docker image
+is using the most recent PHP 7 release.
+
+When this is run, it will return an exit code of zero (0) if it is using the
+most recent PHP 7 release, and an exit code of one (1) if it is not. It also
+writes out some basic information to stdout for easier reading by humans.
+
+Ideally, you would run this automatically on some regular schedule (such as
+daily), and if it returns a non-zero exit code, you know you need to update the
+PHP version specified in the base image's Dockerfile:  
+<https://github.com/silinternational/docker-php7-apache/blob/main/Dockerfile>
+
+Once that repo has been updated, it will automatically submit PRs on all GitHub
+repos that use it as their base image, including this one. At that point, the
+next time this image runs, it should return a zero exit code until a new version
+of PHP 7 is released.

--- a/check-version.php
+++ b/check-version.php
@@ -1,0 +1,27 @@
+<?php
+
+$majorVersionInUse = PHP_MAJOR_VERSION;
+$fullVersionInUse = phpversion();
+echo sprintf(
+    "Using PHP %s\n",
+    $fullVersionInUse
+);
+
+$url = 'https://www.php.net/releases/?json&version=' . $majorVersionInUse;
+$releaseJson = file_get_contents($url);
+$releaseData = json_decode($releaseJson, true);
+$latestRelease = $releaseData['version'];
+echo sprintf(
+    "Latest PHP %s release: %s\n",
+    $majorVersionInUse,
+    $latestRelease
+);
+
+$isUsingLatestRelease = ($fullVersionInUse === $latestRelease);
+echo sprintf(
+    "This %s using the latest PHP %s release\n",
+    $isUsingLatestRelease ? 'IS' : 'is NOT',
+    $majorVersionInUse
+);
+
+exit($isUsingLatestRelease ? 0 : 1);


### PR DESCRIPTION
I'm attempting to set up an automated process that will notify us whenever a new version of PHP is released and we therefore need to update our docker-php7-apache base image. My thought is that we will run this daily (perhaps on AWS via Lambda?), and if it returns a non-zero exit code we can send an AWS SNS email to ourselves so that we know to update that base repo.

I'll still need to set up Codeship and/or Docker Hub to automatically build this repo's Docker image when it's updated, and then update AWS to run that new version.

@Schparky, do you have experience using AWS Lambda to run a Docker image on a schedule?