### PR TITLE
Allow process to exit naturally if using the latest PHP release

### DIFF
--- a/check-version.php
+++ b/check-version.php
@@ -24,4 +24,6 @@ echo sprintf(
     $majorVersionInUse
 );
 
-exit($isUsingLatestRelease ? 0 : 1);
+if (! $isUsingLatestRelease) {
+    exit(1);
+}


### PR DESCRIPTION
Apparently, AWS Lambda considers any premature exit (even returning an exit code of `0`) to indicate that the Lambda's execution failed. This should, best I can tell, fix this issue for us by allowing the process to exit naturally when we want to indicate success.